### PR TITLE
Update VirtualDesktop package to 2.0.0-beta3, which fixes crashing on RS1

### DIFF
--- a/VirtualDestopCycle/VirtualDesktopManager.csproj
+++ b/VirtualDestopCycle/VirtualDesktopManager.csproj
@@ -94,8 +94,8 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="VirtualDesktop, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtualDesktop.1.0.3\lib\net46\VirtualDesktop.dll</HintPath>
+    <Reference Include="VirtualDesktop, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtualDesktop.2.0.0-beta3\lib\net46\VirtualDesktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/VirtualDestopCycle/packages.config
+++ b/VirtualDestopCycle/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GlobalHotKey" version="1.1.0" targetFramework="net46" />
-  <package id="VirtualDesktop" version="1.0.3" targetFramework="net46" />
+  <package id="VirtualDesktop" version="2.0.0-beta3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
I updated the nuget package for VirtualDesktop to 2.0.0-beta3. This fixes #6 .

I also uploaded [my binaries](https://github.com/mjlim/VirtualDesktopManager/releases/tag/v1.6.0.1), which hopefully helps someone out there who can't build it themselves.
