### PR TITLE
Desktops can now be named, and desktop wallpaper grouping is adjusted

### DIFF
--- a/VirtualDestopCycle/Form1.Designer.cs
+++ b/VirtualDestopCycle/Form1.Designer.cs
@@ -36,6 +36,7 @@
 			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.checkBox1 = new System.Windows.Forms.CheckBox();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.removeButton = new System.Windows.Forms.Button();
 			this.downButton = new System.Windows.Forms.Button();
 			this.upButton = new System.Windows.Forms.Button();
 			this.listView1 = new System.Windows.Forms.ListView();
@@ -43,15 +44,14 @@
 			this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.addFileButton = new System.Windows.Forms.Button();
 			this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
 			this.detailsGroup = new System.Windows.Forms.GroupBox();
-			this.addFileButton = new System.Windows.Forms.Button();
-			this.removeButton = new System.Windows.Forms.Button();
-			this.nameBox = new System.Windows.Forms.TextBox();
-			this.pictureBox = new System.Windows.Forms.PictureBox();
-			this.saveButton = new System.Windows.Forms.Button();
-			this.browseButton = new System.Windows.Forms.Button();
 			this.clearButton = new System.Windows.Forms.Button();
+			this.browseButton = new System.Windows.Forms.Button();
+			this.saveButton = new System.Windows.Forms.Button();
+			this.pictureBox = new System.Windows.Forms.PictureBox();
+			this.nameBox = new System.Windows.Forms.TextBox();
 			this.contextMenuStrip1.SuspendLayout();
 			this.groupBox1.SuspendLayout();
 			this.detailsGroup.SuspendLayout();
@@ -125,6 +125,22 @@
 			this.groupBox1.TabIndex = 3;
 			this.groupBox1.TabStop = false;
 			this.groupBox1.Text = "Desktops";
+			// 
+			// removeButton
+			// 
+			this.removeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.removeButton.BackColor = System.Drawing.Color.Black;
+			this.removeButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.removeButton.Font = new System.Drawing.Font("Segoe UI", 12F);
+			this.removeButton.ForeColor = System.Drawing.Color.White;
+			this.removeButton.Location = new System.Drawing.Point(181, 282);
+			this.removeButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.removeButton.Name = "removeButton";
+			this.removeButton.Size = new System.Drawing.Size(144, 37);
+			this.removeButton.TabIndex = 7;
+			this.removeButton.Text = "Remove";
+			this.removeButton.UseVisualStyleBackColor = false;
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
 			// 
 			// downButton
 			// 
@@ -201,6 +217,22 @@
 			this.columnHeader4.Text = "Image";
 			this.columnHeader4.Width = 160;
 			// 
+			// addFileButton
+			// 
+			this.addFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.addFileButton.BackColor = System.Drawing.Color.Black;
+			this.addFileButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.addFileButton.Font = new System.Drawing.Font("Segoe UI", 12F);
+			this.addFileButton.ForeColor = System.Drawing.Color.White;
+			this.addFileButton.Location = new System.Drawing.Point(14, 282);
+			this.addFileButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.addFileButton.Name = "addFileButton";
+			this.addFileButton.Size = new System.Drawing.Size(163, 37);
+			this.addFileButton.TabIndex = 3;
+			this.addFileButton.Text = "Add background";
+			this.addFileButton.UseVisualStyleBackColor = false;
+			this.addFileButton.Click += new System.EventHandler(this.addFileButton_Click);
+			// 
 			// openFileDialog1
 			// 
 			this.openFileDialog1.FileName = "openFileDialog1";
@@ -222,67 +254,18 @@
 			this.detailsGroup.TabStop = false;
 			this.detailsGroup.Text = "Details";
 			// 
-			// addFileButton
+			// clearButton
 			// 
-			this.addFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.addFileButton.BackColor = System.Drawing.Color.Black;
-			this.addFileButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.addFileButton.Font = new System.Drawing.Font("Segoe UI", 12F);
-			this.addFileButton.ForeColor = System.Drawing.Color.White;
-			this.addFileButton.Location = new System.Drawing.Point(14, 282);
-			this.addFileButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.addFileButton.Name = "addFileButton";
-			this.addFileButton.Size = new System.Drawing.Size(163, 37);
-			this.addFileButton.TabIndex = 3;
-			this.addFileButton.Text = "Add background";
-			this.addFileButton.UseVisualStyleBackColor = false;
-			this.addFileButton.Click += new System.EventHandler(this.addFileButton_Click);
-			// 
-			// removeButton
-			// 
-			this.removeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.removeButton.BackColor = System.Drawing.Color.Black;
-			this.removeButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.removeButton.Font = new System.Drawing.Font("Segoe UI", 12F);
-			this.removeButton.ForeColor = System.Drawing.Color.White;
-			this.removeButton.Location = new System.Drawing.Point(181, 282);
-			this.removeButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.removeButton.Name = "removeButton";
-			this.removeButton.Size = new System.Drawing.Size(144, 37);
-			this.removeButton.TabIndex = 7;
-			this.removeButton.Text = "Remove";
-			this.removeButton.UseVisualStyleBackColor = false;
-			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
-			// 
-			// nameBox
-			// 
-			this.nameBox.Location = new System.Drawing.Point(14, 48);
-			this.nameBox.Name = "nameBox";
-			this.nameBox.Size = new System.Drawing.Size(363, 49);
-			this.nameBox.TabIndex = 0;
-			this.nameBox.TextChanged += new System.EventHandler(this.nameBox_TextChanged);
-			// 
-			// pictureBox
-			// 
-			this.pictureBox.Location = new System.Drawing.Point(383, 48);
-			this.pictureBox.Name = "pictureBox";
-			this.pictureBox.Size = new System.Drawing.Size(194, 139);
-			this.pictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-			this.pictureBox.TabIndex = 1;
-			this.pictureBox.TabStop = false;
-			// 
-			// saveButton
-			// 
-			this.saveButton.BackColor = System.Drawing.Color.Black;
-			this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.saveButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.saveButton.Location = new System.Drawing.Point(14, 150);
-			this.saveButton.Name = "saveButton";
-			this.saveButton.Size = new System.Drawing.Size(144, 37);
-			this.saveButton.TabIndex = 2;
-			this.saveButton.Text = "Save";
-			this.saveButton.UseVisualStyleBackColor = false;
-			this.saveButton.Click += new System.EventHandler(this.saveButton_Click);
+			this.clearButton.BackColor = System.Drawing.Color.Black;
+			this.clearButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.clearButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.clearButton.Location = new System.Drawing.Point(233, 103);
+			this.clearButton.Name = "clearButton";
+			this.clearButton.Size = new System.Drawing.Size(144, 37);
+			this.clearButton.TabIndex = 4;
+			this.clearButton.Text = "Clear Image";
+			this.clearButton.UseVisualStyleBackColor = false;
+			this.clearButton.Click += new System.EventHandler(this.clearButton_Click);
 			// 
 			// browseButton
 			// 
@@ -297,17 +280,35 @@
 			this.browseButton.UseVisualStyleBackColor = false;
 			this.browseButton.Click += new System.EventHandler(this.browseButton_Click);
 			// 
-			// clearButton
+			// saveButton
 			// 
-			this.clearButton.BackColor = System.Drawing.Color.Black;
-			this.clearButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.clearButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.clearButton.Location = new System.Drawing.Point(233, 103);
-			this.clearButton.Name = "clearButton";
-			this.clearButton.Size = new System.Drawing.Size(144, 37);
-			this.clearButton.TabIndex = 4;
-			this.clearButton.Text = "Clear Image";
-			this.clearButton.UseVisualStyleBackColor = false;
+			this.saveButton.BackColor = System.Drawing.Color.Black;
+			this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.saveButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.saveButton.Location = new System.Drawing.Point(14, 150);
+			this.saveButton.Name = "saveButton";
+			this.saveButton.Size = new System.Drawing.Size(144, 37);
+			this.saveButton.TabIndex = 2;
+			this.saveButton.Text = "Save";
+			this.saveButton.UseVisualStyleBackColor = false;
+			this.saveButton.Click += new System.EventHandler(this.saveButton_Click);
+			// 
+			// pictureBox
+			// 
+			this.pictureBox.Location = new System.Drawing.Point(383, 48);
+			this.pictureBox.Name = "pictureBox";
+			this.pictureBox.Size = new System.Drawing.Size(194, 139);
+			this.pictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+			this.pictureBox.TabIndex = 1;
+			this.pictureBox.TabStop = false;
+			// 
+			// nameBox
+			// 
+			this.nameBox.Location = new System.Drawing.Point(14, 48);
+			this.nameBox.Name = "nameBox";
+			this.nameBox.Size = new System.Drawing.Size(363, 49);
+			this.nameBox.TabIndex = 0;
+			this.nameBox.TextChanged += new System.EventHandler(this.nameBox_TextChanged);
 			// 
 			// Form1
 			// 

--- a/VirtualDestopCycle/Form1.Designer.cs
+++ b/VirtualDestopCycle/Form1.Designer.cs
@@ -28,241 +28,318 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
-            this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
-            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.removeButton = new System.Windows.Forms.Button();
-            this.downButton = new System.Windows.Forms.Button();
-            this.upButton = new System.Windows.Forms.Button();
-            this.listView1 = new System.Windows.Forms.ListView();
-            this.addFileButton = new System.Windows.Forms.Button();
-            this.saveButton = new System.Windows.Forms.Button();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.labelStatus = new System.Windows.Forms.Label();
-            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
-            this.contextMenuStrip1.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // notifyIcon1
-            // 
-            this.notifyIcon1.ContextMenuStrip = this.contextMenuStrip1;
-            this.notifyIcon1.Icon = global::VirtualDesktopManager.Properties.Resources.mainIco;
-            this.notifyIcon1.Text = "Virtual Desktop Manager";
-            this.notifyIcon1.Visible = true;
-            this.notifyIcon1.DoubleClick += new System.EventHandler(this.notifyIcon1_DoubleClick);
-            // 
-            // contextMenuStrip1
-            // 
-            this.contextMenuStrip1.ImageScalingSize = new System.Drawing.Size(28, 28);
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+			this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
+			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.checkBox1 = new System.Windows.Forms.CheckBox();
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.downButton = new System.Windows.Forms.Button();
+			this.upButton = new System.Windows.Forms.Button();
+			this.listView1 = new System.Windows.Forms.ListView();
+			this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+			this.detailsGroup = new System.Windows.Forms.GroupBox();
+			this.addFileButton = new System.Windows.Forms.Button();
+			this.removeButton = new System.Windows.Forms.Button();
+			this.nameBox = new System.Windows.Forms.TextBox();
+			this.pictureBox = new System.Windows.Forms.PictureBox();
+			this.saveButton = new System.Windows.Forms.Button();
+			this.browseButton = new System.Windows.Forms.Button();
+			this.clearButton = new System.Windows.Forms.Button();
+			this.contextMenuStrip1.SuspendLayout();
+			this.groupBox1.SuspendLayout();
+			this.detailsGroup.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// notifyIcon1
+			// 
+			this.notifyIcon1.ContextMenuStrip = this.contextMenuStrip1;
+			this.notifyIcon1.Icon = global::VirtualDesktopManager.Properties.Resources.mainIco;
+			this.notifyIcon1.Text = "Virtual Desktop Manager";
+			this.notifyIcon1.Visible = true;
+			this.notifyIcon1.DoubleClick += new System.EventHandler(this.notifyIcon1_DoubleClick);
+			// 
+			// contextMenuStrip1
+			// 
+			this.contextMenuStrip1.ImageScalingSize = new System.Drawing.Size(28, 28);
+			this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.settingsToolStripMenuItem,
             this.exitToolStripMenuItem});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(117, 48);
-            // 
-            // settingsToolStripMenuItem
-            // 
-            this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
-            this.settingsToolStripMenuItem.Text = "Settings";
-            this.settingsToolStripMenuItem.Click += new System.EventHandler(this.settingsToolStripMenuItem_Click);
-            // 
-            // exitToolStripMenuItem
-            // 
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
-            this.exitToolStripMenuItem.Text = "Exit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
-            // 
-            // checkBox1
-            // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.checkBox1.ForeColor = System.Drawing.Color.White;
-            this.checkBox1.Location = new System.Drawing.Point(14, 54);
-            this.checkBox1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(353, 21);
-            this.checkBox1.TabIndex = 1;
-            this.checkBox1.Text = "Use alternate key combination (Shift+Alt+Left/Right)";
-            this.checkBox1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.checkBox1.UseVisualStyleBackColor = true;
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.contextMenuStrip1.Name = "contextMenuStrip1";
+			this.contextMenuStrip1.Size = new System.Drawing.Size(128, 52);
+			// 
+			// settingsToolStripMenuItem
+			// 
+			this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
+			this.settingsToolStripMenuItem.Size = new System.Drawing.Size(127, 24);
+			this.settingsToolStripMenuItem.Text = "Settings";
+			this.settingsToolStripMenuItem.Click += new System.EventHandler(this.settingsToolStripMenuItem_Click);
+			// 
+			// exitToolStripMenuItem
+			// 
+			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+			this.exitToolStripMenuItem.Size = new System.Drawing.Size(127, 24);
+			this.exitToolStripMenuItem.Text = "Exit";
+			this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+			// 
+			// checkBox1
+			// 
+			this.checkBox1.AutoSize = true;
+			this.checkBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.checkBox1.ForeColor = System.Drawing.Color.White;
+			this.checkBox1.Location = new System.Drawing.Point(14, 54);
+			this.checkBox1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.checkBox1.Name = "checkBox1";
+			this.checkBox1.Size = new System.Drawing.Size(396, 24);
+			this.checkBox1.TabIndex = 1;
+			this.checkBox1.Text = "Use alternate key combination (Shift+Alt+Left/Right)";
+			this.checkBox1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			this.checkBox1.UseVisualStyleBackColor = true;
+			this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.BackColor = System.Drawing.Color.Black;
-            this.groupBox1.Controls.Add(this.removeButton);
-            this.groupBox1.Controls.Add(this.downButton);
-            this.groupBox1.Controls.Add(this.upButton);
-            this.groupBox1.Controls.Add(this.listView1);
-            this.groupBox1.Controls.Add(this.addFileButton);
-            this.groupBox1.Controls.Add(this.saveButton);
-            this.groupBox1.Controls.Add(this.checkBox1);
-            this.groupBox1.Font = new System.Drawing.Font("Segoe UI", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.groupBox1.ForeColor = System.Drawing.Color.White;
-            this.groupBox1.Location = new System.Drawing.Point(8, 9);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.groupBox1.Size = new System.Drawing.Size(593, 347);
-            this.groupBox1.TabIndex = 3;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Settings";
-            // 
-            // removeButton
-            // 
-            this.removeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.removeButton.BackColor = System.Drawing.Color.Black;
-            this.removeButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.removeButton.Font = new System.Drawing.Font("Segoe UI", 12F);
-            this.removeButton.ForeColor = System.Drawing.Color.White;
-            this.removeButton.Location = new System.Drawing.Point(175, 282);
-            this.removeButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.removeButton.Name = "removeButton";
-            this.removeButton.Size = new System.Drawing.Size(144, 37);
-            this.removeButton.TabIndex = 7;
-            this.removeButton.Text = "Remove file";
-            this.removeButton.UseVisualStyleBackColor = false;
-            this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
-            // 
-            // downButton
-            // 
-            this.downButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.downButton.BackColor = System.Drawing.Color.Black;
-            this.downButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.downButton.Font = new System.Drawing.Font("Wingdings", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
-            this.downButton.ForeColor = System.Drawing.Color.White;
-            this.downButton.Location = new System.Drawing.Point(539, 188);
-            this.downButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.downButton.Name = "downButton";
-            this.downButton.Size = new System.Drawing.Size(41, 37);
-            this.downButton.TabIndex = 6;
-            this.downButton.Text = "â";
-            this.downButton.UseVisualStyleBackColor = false;
-            this.downButton.Click += new System.EventHandler(this.downButton_Click);
-            // 
-            // upButton
-            // 
-            this.upButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.upButton.BackColor = System.Drawing.Color.Black;
-            this.upButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.upButton.Font = new System.Drawing.Font("Wingdings", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
-            this.upButton.ForeColor = System.Drawing.Color.White;
-            this.upButton.Location = new System.Drawing.Point(539, 128);
-            this.upButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.upButton.Name = "upButton";
-            this.upButton.Size = new System.Drawing.Size(41, 37);
-            this.upButton.TabIndex = 5;
-            this.upButton.Text = "á";
-            this.upButton.UseVisualStyleBackColor = false;
-            this.upButton.Click += new System.EventHandler(this.upButton_Click);
-            // 
-            // listView1
-            // 
-            this.listView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			this.groupBox1.BackColor = System.Drawing.Color.Black;
+			this.groupBox1.Controls.Add(this.removeButton);
+			this.groupBox1.Controls.Add(this.downButton);
+			this.groupBox1.Controls.Add(this.upButton);
+			this.groupBox1.Controls.Add(this.listView1);
+			this.groupBox1.Controls.Add(this.addFileButton);
+			this.groupBox1.Controls.Add(this.checkBox1);
+			this.groupBox1.Font = new System.Drawing.Font("Segoe UI", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.groupBox1.ForeColor = System.Drawing.Color.White;
+			this.groupBox1.Location = new System.Drawing.Point(8, 9);
+			this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.groupBox1.Size = new System.Drawing.Size(593, 347);
+			this.groupBox1.TabIndex = 3;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "Desktops";
+			// 
+			// downButton
+			// 
+			this.downButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.downButton.BackColor = System.Drawing.Color.Black;
+			this.downButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.downButton.Font = new System.Drawing.Font("Wingdings", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
+			this.downButton.ForeColor = System.Drawing.Color.White;
+			this.downButton.Location = new System.Drawing.Point(539, 188);
+			this.downButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.downButton.Name = "downButton";
+			this.downButton.Size = new System.Drawing.Size(41, 37);
+			this.downButton.TabIndex = 6;
+			this.downButton.Text = "â";
+			this.downButton.UseVisualStyleBackColor = false;
+			this.downButton.Click += new System.EventHandler(this.downButton_Click);
+			// 
+			// upButton
+			// 
+			this.upButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.upButton.BackColor = System.Drawing.Color.Black;
+			this.upButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.upButton.Font = new System.Drawing.Font("Wingdings", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
+			this.upButton.ForeColor = System.Drawing.Color.White;
+			this.upButton.Location = new System.Drawing.Point(539, 128);
+			this.upButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.upButton.Name = "upButton";
+			this.upButton.Size = new System.Drawing.Size(41, 37);
+			this.upButton.TabIndex = 5;
+			this.upButton.Text = "á";
+			this.upButton.UseVisualStyleBackColor = false;
+			this.upButton.Click += new System.EventHandler(this.upButton_Click);
+			// 
+			// listView1
+			// 
+			this.listView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.listView1.Font = new System.Drawing.Font("Segoe UI", 12F);
-            this.listView1.HideSelection = false;
-            this.listView1.Location = new System.Drawing.Point(14, 98);
-            this.listView1.Name = "listView1";
-            this.listView1.ShowGroups = false;
-            this.listView1.ShowItemToolTips = true;
-            this.listView1.Size = new System.Drawing.Size(508, 168);
-            this.listView1.TabIndex = 4;
-            this.listView1.UseCompatibleStateImageBehavior = false;
-            this.listView1.View = System.Windows.Forms.View.Details;
-            // 
-            // addFileButton
-            // 
-            this.addFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.addFileButton.BackColor = System.Drawing.Color.Black;
-            this.addFileButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.addFileButton.Font = new System.Drawing.Font("Segoe UI", 12F);
-            this.addFileButton.ForeColor = System.Drawing.Color.White;
-            this.addFileButton.Location = new System.Drawing.Point(14, 282);
-            this.addFileButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.addFileButton.Name = "addFileButton";
-            this.addFileButton.Size = new System.Drawing.Size(144, 37);
-            this.addFileButton.TabIndex = 3;
-            this.addFileButton.Text = "Add background";
-            this.addFileButton.UseVisualStyleBackColor = false;
-            this.addFileButton.Click += new System.EventHandler(this.addFileButton_Click);
-            // 
-            // saveButton
-            // 
-            this.saveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.saveButton.BackColor = System.Drawing.Color.Black;
-            this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.saveButton.Font = new System.Drawing.Font("Segoe UI", 12F);
-            this.saveButton.ForeColor = System.Drawing.Color.White;
-            this.saveButton.Location = new System.Drawing.Point(477, 45);
-            this.saveButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(103, 37);
-            this.saveButton.TabIndex = 2;
-            this.saveButton.Text = "Save";
-            this.saveButton.UseVisualStyleBackColor = false;
-            this.saveButton.Click += new System.EventHandler(this.saveButton_Click);
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.pictureBox1.Location = new System.Drawing.Point(8, 363);
-            this.pictureBox1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(171, 76);
-            this.pictureBox1.TabIndex = 4;
-            this.pictureBox1.TabStop = false;
-            // 
-            // labelStatus
-            // 
-            this.labelStatus.AutoSize = true;
-            this.labelStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.labelStatus.Location = new System.Drawing.Point(184, 363);
-            this.labelStatus.Name = "labelStatus";
-            this.labelStatus.Size = new System.Drawing.Size(0, 17);
-            this.labelStatus.TabIndex = 5;
-            // 
-            // openFileDialog1
-            // 
-            this.openFileDialog1.FileName = "openFileDialog1";
-            // 
-            // Form1
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.BackColor = System.Drawing.SystemColors.ActiveCaptionText;
-            this.ClientSize = new System.Drawing.Size(609, 451);
-            this.Controls.Add(this.labelStatus);
-            this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.groupBox1);
-            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F);
-            this.ForeColor = System.Drawing.Color.White;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(1);
-            this.Name = "Form1";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.Text = "Virtual Desktop Manager";
-            this.WindowState = System.Windows.Forms.FormWindowState.Minimized;
-            this.Load += new System.EventHandler(this.Form1_Load);
-            this.contextMenuStrip1.ResumeLayout(false);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.columnHeader1,
+            this.columnHeader2,
+            this.columnHeader3,
+            this.columnHeader4});
+			this.listView1.Font = new System.Drawing.Font("Segoe UI", 12F);
+			this.listView1.FullRowSelect = true;
+			this.listView1.HideSelection = false;
+			this.listView1.Location = new System.Drawing.Point(14, 98);
+			this.listView1.MultiSelect = false;
+			this.listView1.Name = "listView1";
+			this.listView1.ShowGroups = false;
+			this.listView1.ShowItemToolTips = true;
+			this.listView1.Size = new System.Drawing.Size(508, 168);
+			this.listView1.TabIndex = 4;
+			this.listView1.UseCompatibleStateImageBehavior = false;
+			this.listView1.View = System.Windows.Forms.View.Details;
+			this.listView1.SelectedIndexChanged += new System.EventHandler(this.listView1_SelectedIndexChanged);
+			// 
+			// columnHeader1
+			// 
+			this.columnHeader1.Text = "Order";
+			// 
+			// columnHeader2
+			// 
+			this.columnHeader2.Text = "Id";
+			this.columnHeader2.Width = 85;
+			// 
+			// columnHeader3
+			// 
+			this.columnHeader3.Text = "Name";
+			this.columnHeader3.Width = 180;
+			// 
+			// columnHeader4
+			// 
+			this.columnHeader4.Text = "Image";
+			this.columnHeader4.Width = 160;
+			// 
+			// openFileDialog1
+			// 
+			this.openFileDialog1.FileName = "openFileDialog1";
+			// 
+			// detailsGroup
+			// 
+			this.detailsGroup.Controls.Add(this.clearButton);
+			this.detailsGroup.Controls.Add(this.browseButton);
+			this.detailsGroup.Controls.Add(this.saveButton);
+			this.detailsGroup.Controls.Add(this.pictureBox);
+			this.detailsGroup.Controls.Add(this.nameBox);
+			this.detailsGroup.Enabled = false;
+			this.detailsGroup.Font = new System.Drawing.Font("Segoe UI", 20.29091F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.detailsGroup.ForeColor = System.Drawing.Color.White;
+			this.detailsGroup.Location = new System.Drawing.Point(8, 362);
+			this.detailsGroup.Name = "detailsGroup";
+			this.detailsGroup.Size = new System.Drawing.Size(593, 193);
+			this.detailsGroup.TabIndex = 4;
+			this.detailsGroup.TabStop = false;
+			this.detailsGroup.Text = "Details";
+			// 
+			// addFileButton
+			// 
+			this.addFileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.addFileButton.BackColor = System.Drawing.Color.Black;
+			this.addFileButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.addFileButton.Font = new System.Drawing.Font("Segoe UI", 12F);
+			this.addFileButton.ForeColor = System.Drawing.Color.White;
+			this.addFileButton.Location = new System.Drawing.Point(14, 282);
+			this.addFileButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.addFileButton.Name = "addFileButton";
+			this.addFileButton.Size = new System.Drawing.Size(163, 37);
+			this.addFileButton.TabIndex = 3;
+			this.addFileButton.Text = "Add background";
+			this.addFileButton.UseVisualStyleBackColor = false;
+			this.addFileButton.Click += new System.EventHandler(this.addFileButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.removeButton.BackColor = System.Drawing.Color.Black;
+			this.removeButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.removeButton.Font = new System.Drawing.Font("Segoe UI", 12F);
+			this.removeButton.ForeColor = System.Drawing.Color.White;
+			this.removeButton.Location = new System.Drawing.Point(181, 282);
+			this.removeButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+			this.removeButton.Name = "removeButton";
+			this.removeButton.Size = new System.Drawing.Size(144, 37);
+			this.removeButton.TabIndex = 7;
+			this.removeButton.Text = "Remove";
+			this.removeButton.UseVisualStyleBackColor = false;
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// nameBox
+			// 
+			this.nameBox.Location = new System.Drawing.Point(14, 48);
+			this.nameBox.Name = "nameBox";
+			this.nameBox.Size = new System.Drawing.Size(363, 49);
+			this.nameBox.TabIndex = 0;
+			this.nameBox.TextChanged += new System.EventHandler(this.nameBox_TextChanged);
+			// 
+			// pictureBox
+			// 
+			this.pictureBox.Location = new System.Drawing.Point(383, 48);
+			this.pictureBox.Name = "pictureBox";
+			this.pictureBox.Size = new System.Drawing.Size(194, 139);
+			this.pictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+			this.pictureBox.TabIndex = 1;
+			this.pictureBox.TabStop = false;
+			// 
+			// saveButton
+			// 
+			this.saveButton.BackColor = System.Drawing.Color.Black;
+			this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.saveButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.saveButton.Location = new System.Drawing.Point(14, 150);
+			this.saveButton.Name = "saveButton";
+			this.saveButton.Size = new System.Drawing.Size(144, 37);
+			this.saveButton.TabIndex = 2;
+			this.saveButton.Text = "Save";
+			this.saveButton.UseVisualStyleBackColor = false;
+			this.saveButton.Click += new System.EventHandler(this.saveButton_Click);
+			// 
+			// browseButton
+			// 
+			this.browseButton.BackColor = System.Drawing.Color.Black;
+			this.browseButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.browseButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.browseButton.Location = new System.Drawing.Point(233, 150);
+			this.browseButton.Name = "browseButton";
+			this.browseButton.Size = new System.Drawing.Size(144, 37);
+			this.browseButton.TabIndex = 3;
+			this.browseButton.Text = "Browse...";
+			this.browseButton.UseVisualStyleBackColor = false;
+			this.browseButton.Click += new System.EventHandler(this.browseButton_Click);
+			// 
+			// clearButton
+			// 
+			this.clearButton.BackColor = System.Drawing.Color.Black;
+			this.clearButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+			this.clearButton.Font = new System.Drawing.Font("Segoe UI", 11.78182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.clearButton.Location = new System.Drawing.Point(233, 103);
+			this.clearButton.Name = "clearButton";
+			this.clearButton.Size = new System.Drawing.Size(144, 37);
+			this.clearButton.TabIndex = 4;
+			this.clearButton.Text = "Clear Image";
+			this.clearButton.UseVisualStyleBackColor = false;
+			// 
+			// Form1
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.AutoSize = true;
+			this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.BackColor = System.Drawing.SystemColors.ActiveCaptionText;
+			this.ClientSize = new System.Drawing.Size(609, 567);
+			this.Controls.Add(this.detailsGroup);
+			this.Controls.Add(this.groupBox1);
+			this.DoubleBuffered = true;
+			this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F);
+			this.ForeColor = System.Drawing.Color.White;
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.Margin = new System.Windows.Forms.Padding(1);
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "Form1";
+			this.ShowIcon = false;
+			this.ShowInTaskbar = false;
+			this.Text = "Virtual Desktop Manager";
+			this.WindowState = System.Windows.Forms.FormWindowState.Minimized;
+			this.Load += new System.EventHandler(this.Form1_Load);
+			this.contextMenuStrip1.ResumeLayout(false);
+			this.groupBox1.ResumeLayout(false);
+			this.groupBox1.PerformLayout();
+			this.detailsGroup.ResumeLayout(false);
+			this.detailsGroup.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
+			this.ResumeLayout(false);
 
         }
 
@@ -276,15 +353,22 @@
         private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.Button saveButton;
-        private System.Windows.Forms.PictureBox pictureBox1;
-        private System.Windows.Forms.Label labelStatus;
-        private System.Windows.Forms.Button addFileButton;
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.ListView listView1;
         private System.Windows.Forms.Button downButton;
         private System.Windows.Forms.Button upButton;
-        private System.Windows.Forms.Button removeButton;
-    }
+		private System.Windows.Forms.ColumnHeader columnHeader1;
+		private System.Windows.Forms.ColumnHeader columnHeader2;
+		private System.Windows.Forms.ColumnHeader columnHeader3;
+		private System.Windows.Forms.ColumnHeader columnHeader4;
+		private System.Windows.Forms.GroupBox detailsGroup;
+		private System.Windows.Forms.Button removeButton;
+		private System.Windows.Forms.Button addFileButton;
+		private System.Windows.Forms.Button clearButton;
+		private System.Windows.Forms.Button browseButton;
+		private System.Windows.Forms.Button saveButton;
+		private System.Windows.Forms.PictureBox pictureBox;
+		private System.Windows.Forms.TextBox nameBox;
+	}
 }
 

--- a/VirtualDestopCycle/Form1.cs
+++ b/VirtualDestopCycle/Form1.cs
@@ -21,6 +21,8 @@ namespace VirtualDesktopManager
         static extern bool SetForegroundWindow(IntPtr hWnd);
 
         private IList<VirtualDesktop> desktops;
+		private List<VirtualDesktopPreference> Preferences
+			= new List<VirtualDesktopPreference>();
         private IntPtr[] activePrograms;
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
@@ -34,11 +36,53 @@ namespace VirtualDesktopManager
 
         private bool useAltKeySettings;
 
+		private bool saved = true;
+
+		private void LoadDesktopPreferences()
+		{
+			var prefPath = Path.Combine(AppContext.BaseDirectory, "preferences.json");
+			if (System.IO.File.Exists(prefPath))
+			{
+				string contents;
+				using (var stream = System.IO.File.OpenRead(prefPath))
+				{
+					using (StreamReader reader = new StreamReader(stream))
+					{
+						contents = reader.ReadToEnd();
+					}
+				}
+				Preferences = Newtonsoft.Json.JsonConvert.DeserializeObject<List<VirtualDesktopPreference>>(contents);
+				for (int i = 0; i < Preferences.Count; i++)
+				{
+					Preferences[i].VirtualDesktopId = desktops[i].Id;
+				}
+			}
+			else
+			{
+				Preferences = desktops.Select(desktop => new VirtualDesktopPreference() { VirtualDesktopId = desktop.Id }).ToList();
+			}
+		}
+
+		private void SaveDesktopPreferences()
+		{
+			var prefPath = Path.Combine(AppContext.BaseDirectory, "preferences.json");
+			using (var stream = System.IO.File.Create(prefPath))
+			{
+				using (var writer = new StreamWriter(stream))
+				{
+					writer.Write(Newtonsoft.Json.JsonConvert.SerializeObject(Preferences));
+				}
+			}
+		}
+
         public Form1()
         {
             InitializeComponent();
 
             handleChangedNumber();
+			LoadPreferences();
+			LoadDesktopPreferences();
+			RefreshListView();
 
             closeToTray = true;
 
@@ -60,13 +104,88 @@ namespace VirtualDesktopManager
             useAltKeySettings = Properties.Settings.Default.AltHotKey;
             checkBox1.Checked = useAltKeySettings;
 
-            listView1.Items.Clear();
-            listView1.Columns.Add("File").Width = 400;
-            foreach (var file in Properties.Settings.Default.DesktopBackgroundFiles)
-            {
-                listView1.Items.Add(NewListViewItem(file));
-            }
+            //listView1.Items.Clear();
+            //listView1.Columns.Add("File").Width = 400;
+            //foreach (var file in Properties.Settings.Default.DesktopBackgroundFiles)
+            //{
+            //    listView1.Items.Add(NewListViewItem(file));
+            //}
         }
+
+		private void RefreshListView()
+		{
+			for (int i = 0; i < Preferences.Count; i++)
+			{
+				var preference = Preferences[i];
+				var desktop = desktops[i];
+
+				string idStr = preference.VirtualDesktopId.ToString();
+				idStr = "..." + idStr.Substring(idStr.Length - 5);
+				string order = (i + 1).ToString();
+				string name = preference.Name ?? $"Desktop {order}";
+				string path = preference.Wallpaper;
+				path = path == null ? "not set" : Path.GetFileName(path);
+
+				ListViewItem item = null;
+				if (i < listView1.Items.Count)
+					item = listView1.Items[i];
+				if (item == null)
+				{
+					listView1.Items.Add(new ListViewItem(new string[]
+						{
+							order,
+							idStr,
+							name,
+							path
+						}));
+				}
+				else
+				{
+					var subs = item.SubItems;
+					if (subs[0].Text != order)
+						subs[0].Text = order;
+					if (subs[1].Text != idStr)
+						subs[1].Text = idStr;
+					if (subs[2].Text != name)
+						subs[2].Text = name;
+					if (subs[3].Text != path)
+						subs[3].Text = path;
+				}
+			}
+			while (Preferences.Count < listView1.Items.Count)
+			{
+				listView1.Items.RemoveAt(Preferences.Count);
+			}
+		}
+
+		private void RefreshDetails()
+		{
+			if (listView1.SelectedItems.Count != 1)
+			{
+				detailsGroup.Enabled = false;
+			}
+			else
+			{
+				detailsGroup.Enabled = true;
+				var selected = Preferences[listView1.SelectedIndices[0]];
+				saveButton.Enabled = !saved;
+				clearButton.Enabled = (selected.Wallpaper != null);
+				nameBox.Text = selected.Name ?? "";
+				pictureBox.ImageLocation = selected.Wallpaper;
+			}
+		}
+
+		private void LoadPreferences()
+		{
+			Preferences.Clear();
+			foreach (var desktop in desktops)
+			{
+				Preferences.Add(new VirtualDesktopPreference()
+				{
+					VirtualDesktopId = desktop.Id
+				});
+			}
+		}
 
         private void NumberHotkeyPressed(object sender, KeyPressedEventArgs e)
         {   
@@ -128,6 +247,8 @@ namespace VirtualDesktopManager
 
             restoreApplicationFocus(currentDesktopIndex);
             changeTrayIcon(currentDesktopIndex);
+			if (Preferences.Count > currentDesktopIndex)
+				notifyIcon1.Text = Preferences[currentDesktopIndex].Name ?? $"Desktop {currentDesktopIndex + 1}";
         }
 
         private string PickNthFile(int currentDesktopIndex)
@@ -197,7 +318,7 @@ namespace VirtualDesktopManager
 
         private void Form1_Load(object sender, EventArgs e)
         {
-            labelStatus.Text = "";
+            //labelStatus.Text = "";
 
             if (!useAltKeySettings)
                 normalHotkeys();
@@ -329,70 +450,63 @@ namespace VirtualDesktopManager
             openSettings();
         }
 
+		private void MoveSelectedItem(bool up)
+		{
+			int swap = 0;
+			try
+			{
+				if (listView1.SelectedItems.Count == 1)
+				{
+					int indx = listView1.SelectedIndices[0];
+					int totl = listView1.Items.Count;
+					var selected = Preferences[indx];
+
+					if (indx == 0 && up)
+					{
+						swap = totl - 1;
+					}
+					else if (indx == totl - 1 && !up)
+					{
+						swap = 0;
+					}
+					else
+					{
+						swap = indx + (up ? -1 : 1);
+					}
+
+					var name = selected.Name;
+					var wallpaper = selected.Wallpaper;
+
+					var other = Preferences[swap];
+					selected.Name = other.Name;
+					selected.Wallpaper = other.Wallpaper;
+					other.Name = name;
+					other.Wallpaper = wallpaper;
+				}
+				else
+				{
+					MessageBox.Show("You must select exactly one item to move it. Please select one item and try again.",
+						"Item Select", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+				}
+			}
+			catch (Exception) { }
+			finally
+			{
+				RefreshListView();
+				listView1.Items[swap].Selected = true;
+				listView1.Select();
+			}
+		}
+
         private void upButton_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (listView1.SelectedItems.Count > 0)
-                {
-                    ListViewItem selected = listView1.SelectedItems[0];
-                    int indx = selected.Index;
-                    int totl = listView1.Items.Count;
-
-                    if (indx == 0)
-                    {
-                        listView1.Items.Remove(selected);
-                        listView1.Items.Insert(totl - 1, selected);
-                    }
-                    else
-                    {
-                        listView1.Items.Remove(selected);
-                        listView1.Items.Insert(indx - 1, selected);
-                    }
-                }
-                else
-                {
-                    MessageBox.Show("You can only move one item at a time. Please select only one item and try again.",
-                        "Item Select", MessageBoxButtons.OK, MessageBoxIcon.Stop);
-                }
-            }
-            catch (Exception ex)
-            {
-
-            }
+			MoveSelectedItem(true);
         }
 
         private void downButton_Click(object sender, EventArgs e)
-        {
-            try
-            {
-                if (listView1.SelectedItems.Count > 0)
-                {
-                    ListViewItem selected = listView1.SelectedItems[0];
-                    int indx = selected.Index;
-                    int totl = listView1.Items.Count;
-
-                    if (indx == totl - 1)
-                    {
-                        listView1.Items.Remove(selected);
-                        listView1.Items.Insert(0, selected);
-                    }
-                    else
-                    {
-                        listView1.Items.Remove(selected);
-                        listView1.Items.Insert(indx + 1, selected);
-                    }
-                }
-                else
-                {
-                    MessageBox.Show("You can only move one item at a time. Please select only one item and try again.",
-                        "Item Select", MessageBoxButtons.OK, MessageBoxIcon.Stop);
-                }
-            }
-            catch (Exception ex)
-            {
-            }
-        }
+		{
+			MoveSelectedItem(false);
+		}
 
         private void saveButton_Click(object sender, EventArgs e)
         {
@@ -412,32 +526,51 @@ namespace VirtualDesktopManager
                 Properties.Settings.Default.AltHotKey = false;
             }
 
+			if (listView1.SelectedItems.Count == 1)
+			{
+				int indx = listView1.SelectedIndices[0];
+				var preference = Preferences[indx];
+				var name = nameBox.Text;
+				if (name == "")
+					name = null;
+				preference.Name = name;
+				preference.Wallpaper = pictureBox.ImageLocation;
+			}
+
             Properties.Settings.Default.DesktopBackgroundFiles.Clear();
-            foreach (ListViewItem item in listView1.Items)
-            {
-                Properties.Settings.Default.DesktopBackgroundFiles.Add(item.Tag.ToString());
-            }
+			if (Preferences.Any(pref => pref.Wallpaper != null))
+			{
+				string wallpaper = null;
+				for (int i = 0; i < Preferences.Count; i++)
+				{
+					if (wallpaper == null)
+					{
+						var pref = Preferences[(Preferences.Count - i) % Preferences.Count];
+						wallpaper = pref.Wallpaper;
+					}
+				}
+				foreach (var pref in Preferences)
+				{
+					wallpaper = pref.Wallpaper ?? wallpaper;
+					Properties.Settings.Default.DesktopBackgroundFiles.Add(wallpaper);
+				}
+			}
 
             Properties.Settings.Default.Save();
-            labelStatus.Text = "Changes were successful.";
+			SaveDesktopPreferences();
+
+			saved = true;
+			RefreshListView();
+			RefreshDetails();
+            //labelStatus.Text = "Changes were successful.";
         }
 
         private void addFileButton_Click(object sender, EventArgs e)
         {
-            openFileDialog1.CheckFileExists = true;
-            openFileDialog1.CheckPathExists = true;
-            openFileDialog1.Filter = "Image Files(*.BMP;*.JPG;*.GIF)|*.BMP;*.JPG;*.GIF|All files (*.*)|*.*";
-            openFileDialog1.FilterIndex = 0;
-            openFileDialog1.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
-            openFileDialog1.Multiselect = true;
-            openFileDialog1.Title = "Select desktop background image";
-            if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
-            {
-                foreach (string file in openFileDialog1.FileNames)
-                {
-                    listView1.Items.Add(NewListViewItem(file));
-                }
-            }
+			var desktop = VirtualDesktop.Create();
+			handleChangedNumber();
+			Preferences.Add(new VirtualDesktopPreference() { VirtualDesktopId = desktop.Id });
+			RefreshListView();
         }
 
         private static ListViewItem NewListViewItem(string file)
@@ -455,15 +588,69 @@ namespace VirtualDesktopManager
         {
             try
             {
-                if (listView1.SelectedItems.Count > 0)
+				if (listView1.Items.Count == 1)
+				{
+					MessageBox.Show("Can't remove the last desktop.",
+						"Item Select", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+				}
+                else if (listView1.SelectedItems.Count == 1)
                 {
-                    ListViewItem selected = listView1.SelectedItems[0];
-                    listView1.Items.Remove(selected);
-                }
-            }
+					var indx = listView1.SelectedIndices[0];
+					var desktop = desktops[indx];
+					Preferences.RemoveAt(indx);
+					desktop.Remove();
+					handleChangedNumber();
+					RefreshListView();
+				}
+				else
+				{
+					MessageBox.Show("You must select exactly one item to remove it. Please select one item and try again.",
+						"Item Select", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+				}
+			}
             catch (Exception ex)
             {
             }
         }
-    }
+
+		private void button1_Click(object sender, EventArgs e)
+		{
+			VirtualDesktop.Current.GetRight().Switch();
+		}
+
+		private void listView1_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			RefreshDetails();
+		}
+
+		private void browseButton_Click(object sender, EventArgs e)
+		{
+			openFileDialog1.CheckFileExists = true;
+			openFileDialog1.CheckPathExists = true;
+			openFileDialog1.Filter = "Image Files(*.BMP;*.JPG;*.GIF)|*.BMP;*.JPG;*.GIF|All files (*.*)|*.*";
+			openFileDialog1.FilterIndex = 0;
+			openFileDialog1.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+			openFileDialog1.Multiselect = false;
+			openFileDialog1.Title = "Select desktop background image";
+			if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
+			{
+				var path = openFileDialog1.FileName;
+				pictureBox.ImageLocation = path;
+				saved = false;
+				saveButton.Enabled = true;
+			}
+		}
+
+		private void nameBox_TextChanged(object sender, EventArgs e)
+		{
+			saved = false;
+			saveButton.Enabled = true;
+		}
+
+		private void checkBox1_CheckedChanged(object sender, EventArgs e)
+		{
+			saved = false;
+			saveButton.Enabled = true;
+		}
+	}
 }

--- a/VirtualDestopCycle/Form1.cs
+++ b/VirtualDestopCycle/Form1.cs
@@ -236,20 +236,25 @@ namespace VirtualDesktopManager
 
         private void VirtualDesktop_CurrentChanged(object sender, VirtualDesktopChangedEventArgs e)
         {
-            // 0 == first
-            int currentDesktopIndex = getCurrentDesktopIndex();
+			RefreshCurrentDesktop();
+        }
 
-            string pictureFile = PickNthFile(currentDesktopIndex);
-            if (pictureFile != null)
-            {
-                Native.SetBackground(pictureFile);
-            }
+		private void RefreshCurrentDesktop()
+		{
+			// 0 == first
+			int currentDesktopIndex = getCurrentDesktopIndex();
 
-            restoreApplicationFocus(currentDesktopIndex);
-            changeTrayIcon(currentDesktopIndex);
+			string pictureFile = PickNthFile(currentDesktopIndex);
+			if (pictureFile != null)
+			{
+				Native.SetBackground(pictureFile);
+			}
+
+			restoreApplicationFocus(currentDesktopIndex);
+			changeTrayIcon(currentDesktopIndex);
 			if (Preferences.Count > currentDesktopIndex)
 				notifyIcon1.Text = Preferences[currentDesktopIndex].Name ?? $"Desktop {currentDesktopIndex + 1}";
-        }
+		}
 
         private string PickNthFile(int currentDesktopIndex)
         {
@@ -562,6 +567,8 @@ namespace VirtualDesktopManager
 			saved = true;
 			RefreshListView();
 			RefreshDetails();
+
+			RefreshCurrentDesktop();
             //labelStatus.Text = "Changes were successful.";
         }
 
@@ -638,6 +645,7 @@ namespace VirtualDesktopManager
 				pictureBox.ImageLocation = path;
 				saved = false;
 				saveButton.Enabled = true;
+				clearButton.Enabled = true;
 			}
 		}
 
@@ -649,6 +657,13 @@ namespace VirtualDesktopManager
 
 		private void checkBox1_CheckedChanged(object sender, EventArgs e)
 		{
+			saved = false;
+			saveButton.Enabled = true;
+		}
+
+		private void clearButton_Click(object sender, EventArgs e)
+		{
+			pictureBox.ImageLocation = null;
 			saved = false;
 			saveButton.Enabled = true;
 		}

--- a/VirtualDestopCycle/Program.cs
+++ b/VirtualDestopCycle/Program.cs
@@ -16,6 +16,7 @@ namespace VirtualDesktopManager
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+			
             Application.Run(new Form1());
         }
     }

--- a/VirtualDestopCycle/VirtualDesktopManager.csproj
+++ b/VirtualDestopCycle/VirtualDesktopManager.csproj
@@ -83,6 +83,9 @@
       <HintPath>..\packages\GlobalHotKey.1.1.0\lib\GlobalHotKey.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -110,6 +113,7 @@
     <Compile Include="Native.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VirtualDesktopPreference.cs" />
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
     </EmbeddedResource>

--- a/VirtualDestopCycle/VirtualDesktopPreference.cs
+++ b/VirtualDestopCycle/VirtualDesktopPreference.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WindowsDesktop;
+
+namespace VirtualDesktopManager
+{
+	public class VirtualDesktopPreference
+	{
+		public Guid VirtualDesktopId { get; set; }
+		public string Name { get; set; }
+		public string Wallpaper { get; set; }
+	}
+}

--- a/VirtualDestopCycle/packages.config
+++ b/VirtualDestopCycle/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GlobalHotKey" version="1.1.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net46" />
   <package id="VirtualDesktop" version="2.0.0-beta3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
You can name a desktop, and it will show up as a tooltip in the system tray icon for the current desktop. This is good for specifying a purpose for a particular desktop. The wallpaper is now applied specifically per desktop, and if the wallpaper is not set for a particular desktop, it will use the wallpaper of the previous desktop. UI was also updated as such, and the new preferences are stored in a local json file.